### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Lint
 on: pull_request
 


### PR DESCRIPTION
Potential fix for [https://github.com/spejder/ms-vcard/security/code-scanning/4](https://github.com/spejder/ms-vcard/security/code-scanning/4)

To fix the problem, add an explicit `permissions` block to the workflow, restricting permissions to the minimum required. Because the linting jobs do not upload artifacts, create releases, or interact with issues/PRs, they only need `contents: read`. Add a `permissions` key at the top-level (recommended, as it applies to all jobs by default). Edit `.github/workflows/lint.yml` to add:

```yaml
permissions:
  contents: read
```

immediately after the `name: Lint` (line 1), before the `on:` key. No additional code or YAML modifications are needed, and existing functionality is unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
