### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Build and test
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/spejder/ms-vcard/security/code-scanning/2](https://github.com/spejder/ms-vcard/security/code-scanning/2)

To fix the problem, we need to add an explicit `permissions: contents: read` block either at the root of the workflow, which covers all jobs, or as the first property inside jobs/build to scope the least privilege to just the build job. Both are correct, but it's preferable to set it at the workflow root so that it applies to future jobs unless otherwise overridden. Insert the following at the root level, after `name:` and before `on:`:

```yaml
permissions:
  contents: read
```

This grants read-only access to repository contents for all jobs in the workflow, which is enough for `actions/checkout` and should not break any currently shown steps.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
