### PR TITLE
Use GHCR for publishing Docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,12 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Login to DockerHub
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:


### PR DESCRIPTION
It was accidentatially changed to Docker Hub in a357a251273b2c4c879c912e423cbc1c58864c9b (due to bad copy'n'paste).

<!-- 

Please describe the bug fix or feature you would like to introduce.

-->
