### PR TITLE
Update Go version to 1.26.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spejder/ms-vcard
 
-go 1.25.7
+go 1.26.0
 
 require (
 	bitbucket.org/long174/go-odoo v1.12.1


### PR DESCRIPTION
Update Go version to 1.26.0.

See [the release history](https://go.dev/doc/devel/release#go1.26.0).