### PR TITLE
Update Go version to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spejder/ms-vcard
 
-go 1.26.1
+go 1.26.2
 
 require (
 	bitbucket.org/long174/go-odoo v1.12.1


### PR DESCRIPTION
Update Go version to 1.26.2.

See [the release history](https://go.dev/doc/devel/release#go1.26.2).