### PR TITLE
Set explicit timeouts on the HTTP server

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,19 +5,35 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"time"
 
 	"bitbucket.org/long174/go-odoo"
 	"github.com/emersion/go-vcard"
 	"github.com/spejder/ms-vcard/internal/ms"
 )
 
-func main() {
-	addr := getAddr()
+const (
+	readHeaderTimeout = 10 * time.Second
+	readTimeout       = 15 * time.Second
+	// Looking up profiles in Medlemsservice is slow (~890 contacts takes
+	// more than half a minute), so allow plenty of headroom.
+	writeTimeout = 5 * time.Minute
+	idleTimeout  = 60 * time.Second
+)
 
+func main() {
 	http.HandleFunc("/", handler)
 
-	//nolint:gosec
-	err := http.ListenAndServe(addr, nil)
+	srv := &http.Server{
+		Addr:              getAddr(),
+		Handler:           http.DefaultServeMux,
+		ReadHeaderTimeout: readHeaderTimeout,
+		ReadTimeout:       readTimeout,
+		WriteTimeout:      writeTimeout,
+		IdleTimeout:       idleTimeout,
+	}
+
+	err := srv.ListenAndServe()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Fixes code scanning alert [#6](https://github.com/spejder/ms-vcard/security/code-scanning/6) — gosec **G114**, "use of net/http serve function that has no support for setting timeouts", open against `main.go` since 2026-03-01.

## Why the alert never cleared

`main.go` carried a `//nolint:gosec` directive on the `http.ListenAndServe` call, but that is a golangci-lint directive. `.github/workflows/security.yml` runs `securego/gosec` **standalone**, and gosec only honours its own `#nosec` comments — so the suppression hid the finding from `golangci-lint` while the SARIF upload kept reporting it.

## The change

Replaces `http.ListenAndServe(addr, nil)` with an explicit `&http.Server{}` carrying real timeouts, and drops the ineffective `//nolint`. `getAddr()` is reused unchanged, so the `ADDR` env var and its `:80` default behave exactly as before.

`ReadHeaderTimeout` is set explicitly so this does not just trade G114 for **G112** (Slowloris) — the usual trap when fixing G114 with a bare `http.Server` literal.

Timeouts are named constants rather than inline literals, since `linters.default: all` enables `mnd` and its default checks include `operation`/`assign`.

`WriteTimeout` covers the whole handler — including the Odoo XML-RPC calls and the per-profile relation fetches — so it is deliberately generous at 5 minutes. The README documents ~890 contacts taking more than half a minute, so a conventional 30s would truncate large syncs.

## Verification

| Check | Result |
| --- | --- |
| `go build ./...` / `go vet ./...` | pass |
| `gosec -tests ./...` | **G114 gone, no G112 introduced** |
| `gofmt -l` / `gofumpt -l` | clean |
| Server startup on `ADDR=:18080` | serves 401 + `WWW-Authenticate` as before; a credentialed request reaches the Odoo path (500 with fake credentials, as expected) |

The only remaining gosec finding is G404 in `vcard.go` — that is alert #5, already dismissed, and untouched here.

Two caveats: `golangci-lint` was not available locally, so CI's `lint` workflow is the real confirmation (I checked the two things most likely to trip it — formatting and the `mnd` risk). And there is no end-to-end vCard fetch, since that needs real Medlemsservice credentials; the handler itself is unchanged and both auth branches were exercised.

## Out of scope

No graceful shutdown / signal handling — the existing `panic(err)` on serve failure is preserved. Adding `Shutdown` on SIGTERM is a separate concern.